### PR TITLE
Match FileInfoHeader func with tar

### DIFF
--- a/header.go
+++ b/header.go
@@ -90,10 +90,12 @@ func (h *Header) FileInfo() os.FileInfo {
 }
 
 // FileInfoHeader creates a partially-populated Header from fi.
+// If fi describes a symlink, FileInfoHeader records link as the link target.
+// If fi describes a directory, a slash is appended to the name.
 // Because os.FileInfo's Name method returns only the base name of
 // the file it describes, it may be necessary to modify the Name field
 // of the returned header to provide the full path name of the file.
-func FileInfoHeader(fi os.FileInfo) (*Header, error) {
+func FileInfoHeader(fi os.FileInfo, link string) (*Header, error) {
 	if fi == nil {
 		return nil, errors.New("cpio: FileInfo is nil")
 	}
@@ -122,6 +124,7 @@ func FileInfoHeader(fi os.FileInfo) (*Header, error) {
 		h.Name += "/"
 	case fm&os.ModeSymlink != 0:
 		h.Mode |= ModeSymlink
+		h.Linkname = link
 	case fm&os.ModeDevice != 0:
 		if fm&os.ModeCharDevice != 0 {
 			h.Mode |= ModeCharDevice


### PR DESCRIPTION
A small change to match tar's signature of the FileInfoHeader function