### PR TITLE
FileInfoHeader: set Size = 0 for directories

### DIFF
--- a/header.go
+++ b/header.go
@@ -122,6 +122,7 @@ func FileInfoHeader(fi os.FileInfo, link string) (*Header, error) {
 	case fi.IsDir():
 		h.Mode |= ModeDir
 		h.Name += "/"
+		h.Size = 0
 	case fm&os.ModeSymlink != 0:
 		h.Mode |= ModeSymlink
 		h.Linkname = link

--- a/testdata/etc/hosts
+++ b/testdata/etc/hosts
@@ -1,0 +1,2 @@
+127.0.0.1 localhost
+::1 localhost

--- a/writer_test.go
+++ b/writer_test.go
@@ -1,0 +1,53 @@
+package cpio_test
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+
+	cpio "github.com/cavaliercoder/go-cpio"
+)
+
+func store(w *cpio.Writer, fn string) error {
+	f, err := os.Open(fn)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	fi, err := f.Stat()
+	if err != nil {
+		return err
+	}
+	hdr, err := cpio.FileInfoHeader(fi, "")
+	if err != nil {
+		return err
+	}
+	if err := w.WriteHeader(hdr); err != nil {
+		return err
+	}
+	if !fi.IsDir() {
+		if _, err := io.Copy(w, f); err != nil {
+			return err
+		}
+	}
+
+	return err
+}
+
+func TestWriter(t *testing.T) {
+	var buf bytes.Buffer
+	w := cpio.NewWriter(&buf)
+
+	if err := store(w, "testdata/etc"); err != nil {
+		t.Fatalf("store: %v", err)
+	}
+
+	if err := store(w, "testdata/etc/hosts"); err != nil {
+		t.Fatalf("store: %v", err)
+	}
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}


### PR DESCRIPTION
Without this change, I’m getting errors like “cpio: missed writing 4096 bytes”
when trying to write the headers for directories.