### PR TITLE
Fix write of Symlink files

### DIFF
--- a/header.go
+++ b/header.go
@@ -126,6 +126,7 @@ func FileInfoHeader(fi os.FileInfo, link string) (*Header, error) {
 	case fm&os.ModeSymlink != 0:
 		h.Mode |= ModeSymlink
 		h.Linkname = link
+		h.Size = 0 // adjusted to len(Linkname) while writing header
 	case fm&os.ModeDevice != 0:
 		if fm&os.ModeCharDevice != 0 {
 			h.Mode |= ModeCharDevice

--- a/writer_test.go
+++ b/writer_test.go
@@ -10,23 +10,32 @@ import (
 )
 
 func store(w *cpio.Writer, fn string) error {
-	f, err := os.Open(fn)
+	fi, err := os.Lstat(fn)
 	if err != nil {
 		return err
 	}
-	defer f.Close()
-	fi, err := f.Stat()
+	var link string
+	if fi.Mode()&os.ModeSymlink != 0 {
+		if link, err = os.Readlink(fn); err != nil {
+			return err
+		}
+	}
+	hdr, err := cpio.FileInfoHeader(fi, link)
 	if err != nil {
 		return err
 	}
-	hdr, err := cpio.FileInfoHeader(fi, "")
-	if err != nil {
-		return err
+	if hdr.Mode&^cpio.ModePerm == cpio.ModeSymlink {
+		hdr.Size = 0 // FIXME: should be done in FileInfoHeader
 	}
 	if err := w.WriteHeader(hdr); err != nil {
 		return err
 	}
-	if !fi.IsDir() {
+	if fi.Mode().IsRegular() {
+		f, err := os.Open(fn)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
 		if _, err := io.Copy(w, f); err != nil {
 			return err
 		}
@@ -45,5 +54,31 @@ func TestWriter(t *testing.T) {
 	}
 	if err := w.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
+	}
+}
+
+func TestWriter_Symlink(t *testing.T) {
+	var buf bytes.Buffer
+	w := cpio.NewWriter(&buf)
+	func() {
+		defer func() {
+			if err := w.Close(); err != nil {
+				t.Fatalf("Close: %v", err)
+			}
+		}()
+		if err := store(w, "testdata/checklist.txt"); err != nil {
+			t.Fatalf("store: %v", err)
+		}
+	}()
+	r := cpio.NewReader(&buf)
+	hdr, err := r.Next()
+	if err != nil {
+		t.Fatalf("Next: %v", err)
+	}
+	if hdr.Mode&^cpio.ModePerm != cpio.ModeSymlink {
+		t.Fatalf("file has mode %s, expected %s (ModeSymlink)", hdr.Mode, cpio.FileMode(cpio.ModeSymlink))
+	}
+	if hdr.Linkname == "" {
+		t.Fatal("Empty Linkname on ModeSymlink file")
 	}
 }

--- a/writer_test.go
+++ b/writer_test.go
@@ -24,9 +24,6 @@ func store(w *cpio.Writer, fn string) error {
 	if err != nil {
 		return err
 	}
-	if hdr.Mode&^cpio.ModePerm == cpio.ModeSymlink {
-		hdr.Size = 0 // FIXME: should be done in FileInfoHeader
-	}
 	if err := w.WriteHeader(hdr); err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes #15

`writeSVR4Header()` currently omits the following for files with mode Symlink:
- The file's Size must match the link target (Linkname)
- The link target must be written after the pad that follows the file's name

Both match the way `readSVR4Header()` translates the final read into a Linkname (and returned file size of 0).